### PR TITLE
EB-1124: [customer support] ebook fails to convert

### DIFF
--- a/green_onion.gemspec
+++ b/green_onion.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "capybara"
   gem.add_dependency "oily_png", "~> 1.0.2"
   gem.add_dependency "rainbow"
-  gem.add_dependency "fileutils"
   gem.add_dependency "thor", ">= 0.14.6"
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
 remove filetils because it is default library or ruby